### PR TITLE
Fix example output part 9 ex.8

### DIFF
--- a/data/osa-9/2-oliot-attribuuttina.md
+++ b/data/osa-9/2-oliot-attribuuttina.md
@@ -418,7 +418,7 @@ Huone tyhjä? True
 Lyhin: None
 
 Huone tyhjä? False
-Lyhin: Nina
+Lyhin: Nina (172 cm)
 
 Huoneessa 4 henkilöä, yhteispituus 723 cm
 Lea (183 cm)


### PR DESCRIPTION
Osassa 9 tehtävässä 8 Huoneen lyhin esimerkkitulostuksessa tulostettiin vain lyhyimmän henkilön nimi, mikä saattoi johtaa päätelmään, että funktion lyhin() tulisi palauttaa Henkilo-olion sijaan henkilön nimi. Korjasin tulostuksen vastaamaan tulostusta, jossa huone.lyhin() palauttaa Henkilo-olion.